### PR TITLE
BugFix - Removed Image Balloon on Poster, BackArrow Icon now works on click

### DIFF
--- a/app/src/main/java/com/skydoves/disneycompose/ui/details/PosterDetails.kt
+++ b/app/src/main/java/com/skydoves/disneycompose/ui/details/PosterDetails.kt
@@ -87,6 +87,14 @@ fun PosterDetails(
             }
             .padding(16.dp)
         )
+        ImageBalloonAnchor(
+          reference = image,
+          modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(0.85f),
+          content = poster.name,
+          onClick = { balloon, anchor -> balloon.showAlignBottom(anchor) }
+        )
         Icon(
           imageVector = Icons.Filled.ArrowBack,
           contentDescription = null,

--- a/app/src/main/java/com/skydoves/disneycompose/ui/details/PosterDetails.kt
+++ b/app/src/main/java/com/skydoves/disneycompose/ui/details/PosterDetails.kt
@@ -97,14 +97,7 @@ fun PosterDetails(
             .padding(12.dp)
             .clickable(onClick = { pressOnBack() })
         )
-        ImageBalloonAnchor(
-          reference = image,
-          modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(0.85f),
-          content = poster.name,
-          onClick = { balloon, anchor -> balloon.showAlignBottom(anchor) }
-        )
+
       }
     }
   }


### PR DESCRIPTION
Previously when the back arrow icon was pressed on the poster image, the balloon displayed at the bottom of the poster with the title of the movie. Now when the back arrow is pressed, it will go back to the previous screen. User could press the back arrow on the phone, but that defeated the purpose of the back arrow icon on the poster as well I felt. 

I should mention this is my first contribution too to an open source project outside of my own, but I felt I followed the directions to allow this fix. If not please let me know and I will listen to the feedback. Thank you.

## Guidelines
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

### Types of changes
What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.