### PR TITLE
Bump compose 1.0.0 stable and landscapist to 1.3.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,13 +12,13 @@ ext.versions = [
     materialVersion      : '1.3.0-alpha03',
 
     // compose
-    composeVersion       : '1.0.0-rc01',
+    composeVersion       : '1.0.0',
     constraintVersion    : '1.0.0-alpha07',
     activityVersion      : '1.3.0-rc02',
     composeNavVersion    : '2.4.0-alpha02',
 
     // compose image loading
-    landscapistVersion   : '1.2.8',
+    landscapistVersion   : '1.3.0',
 
     // compose compatibles
     orchestraVersion     : '1.0.8',


### PR DESCRIPTION
## Guidelines
Bump compose 1.0.0 stable and landscapist to 1.3.0