### PR TITLE
Bump Compose to 1.1.0 and landscapist & orchestra versions

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,16 +12,16 @@ ext.versions = [
     materialVersion      : '1.5.0',
 
     // compose
-    composeVersion       : '1.1.0-rc03',
+    composeVersion       : '1.1.0',
     constraintVersion    : '1.0.0-rc01',
     activityVersion      : '1.4.0',
     composeNavVersion    : '2.4.0-alpha05',
 
     // compose image loading
-    landscapistVersion   : '1.4.6',
+    landscapistVersion   : '1.4.8',
 
     // compose compatibles
-    orchestraVersion     : '1.1.1',
+    orchestraVersion     : '1.1.3',
 
     // compose insets
     accompanistVersion   : '0.20.2',
@@ -33,7 +33,7 @@ ext.versions = [
     archCompomentVersion : '2.1.0',
 
     // startup
-    startupVersion       : '1.1.0',
+    startupVersion       : '1.1.1',
 
     // di
     hiltVersion          : '2.40.5',


### PR DESCRIPTION
## Overview
Bump Compose to 1.1.0 and landscapist & orchestra versions.