### PR TITLE
Bump Compose compiler to 1.4.0, kotlin to 1.8.0 and landscapist to 2.1.2

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,20 +6,20 @@ ext.versions = [
 
         gradleBuildTool      : '7.3.0',
         spotlessGradle       : '6.7.0',
-        kotlin               : '1.7.20',
+        kotlin               : '1.8.0',
 
         // material
         materialVersion      : '1.6.0',
 
         // compose
-        composeCompiler      : '1.3.2',
+        composeCompiler      : '1.4.0',
         composeVersion       : '1.3.1',
         constraintVersion    : '1.0.0',
         activityVersion      : '1.4.0',
         composeNavVersion    : '2.5.0',
 
         // compose image loading
-        landscapistVersion   : '2.1.0',
+        landscapistVersion   : '2.1.2',
 
         // accompanist
         accompanistVersion   : '0.28.0',


### PR DESCRIPTION
## Guidelines
Bump Compose compiler to 1.4.0, kotlin to 1.8.0 and landscapist to 2.1.2.